### PR TITLE
Make splitting an empty string give 1 empty result

### DIFF
--- a/src/nre.nim
+++ b/src/nre.nim
@@ -387,7 +387,7 @@ proc split*(str: string, pattern: Regex, maxSplit = -1, start = 0): seq[string] 
   result = @[]
   var lastIdx = start
   var splits = 0
-  var bounds = 0 .. -1
+  var bounds = 0 .. 0
 
   for match in str.findIter(pattern, start = start):
     # bounds are inclusive:

--- a/test/split.nim
+++ b/test/split.nim
@@ -7,7 +7,7 @@ suite "string splitting":
     check("1  2  ".split(re(" ")) == @["1", "", "2", "", ""])
     check("1 2".split(re(" ")) == @["1", "2"])
     check("foo".split(re("foo")) == @["", ""])
-    check("".split(re"foo") == newSeq[string]())
+    check("".split(re"foo") == @[""])
 
   test "captured patterns":
     check("12".split(re"(\d)") == @["", "1", "", "2", ""])


### PR DESCRIPTION
According to Python's and JavaScript's behavior:

``` python
re.split(r"(foo)", "") == ['']
```

Odd number of results seems consistent with:

``` python
re.split(r"(foo)", "foo") == ['', 'foo', '']
```
