### PR TITLE
Remove optional_t from nimble

### DIFF
--- a/nre.nimble
+++ b/nre.nimble
@@ -8,4 +8,3 @@ srcDir      = "src"
 
 [Deps]
 Requires: "nim >= 0.11.2"
-Requires: "optional_t >= 1.2.0"


### PR DESCRIPTION
Doesn't look like it's required anymore.
